### PR TITLE
Merge from azure/azure-powershell into my fork cheguv/azure-powershell

### DIFF
--- a/src/Common/Commands.Common/GeneralUtilities.cs
+++ b/src/Common/Commands.Common/GeneralUtilities.cs
@@ -251,6 +251,11 @@ namespace Microsoft.WindowsAzure.Commands.Utilities.Common
 
         public static string EnsureTrailingSlash(string url)
         {
+            if (string.IsNullOrWhiteSpace(url))
+            {
+                return url;
+            }
+
             UriBuilder address = new UriBuilder(url);
             if (!address.Path.EndsWith("/", StringComparison.Ordinal))
             {

--- a/src/ResourceManager/Profile/Commands.Profile.Test/EnvironmentCmdletTests.cs
+++ b/src/ResourceManager/Profile/Commands.Profile.Test/EnvironmentCmdletTests.cs
@@ -239,19 +239,19 @@ namespace Microsoft.Azure.Commands.ResourceManager.Profile.Test
             {
                 CommandRuntime = commandRuntimeMock.Object,
                 Name = "Katal",
-                ActiveDirectoryEndpoint = "ActiveDirectoryEndpoint",
+                ActiveDirectoryEndpoint = "https://ActiveDirectoryEndpoint",
                 AdTenant = "AdTenant",
                 AzureKeyVaultDnsSuffix = "AzureKeyVaultDnsSuffix",
-                ActiveDirectoryServiceEndpointResourceId = "ActiveDirectoryServiceEndpointResourceId",
-                AzureKeyVaultServiceEndpointResourceId = "AzureKeyVaultServiceEndpointResourceId",
+                ActiveDirectoryServiceEndpointResourceId = "https://ActiveDirectoryServiceEndpointResourceId",
+                AzureKeyVaultServiceEndpointResourceId = "https://AzureKeyVaultServiceEndpointResourceId",
                 EnableAdfsAuthentication = true,
-                GalleryEndpoint = "GalleryEndpoint",
-                GraphEndpoint = "GraphEndpoint",
-                ManagementPortalUrl = "ManagementPortalUrl",
-                PublishSettingsFileUrl = "PublishSettingsFileUrl",
-                ResourceManagerEndpoint = "ResourceManagerEndpoint",
-                ServiceEndpoint = "ServiceEndpoint",
-                StorageEndpoint = "StorageEndpoint",
+                GalleryEndpoint = "https://GalleryEndpoint",
+                GraphEndpoint = "https://GraphEndpoint",
+                ManagementPortalUrl = "https://ManagementPortalUrl",
+                PublishSettingsFileUrl = "https://PublishSettingsFileUrl",
+                ResourceManagerEndpoint = "https://ResourceManagerEndpoint",
+                ServiceEndpoint = "https://ServiceEndpoint",
+                StorageEndpoint = "https://StorageEndpoint",
                 SqlDatabaseDnsSuffix = "SqlDatabaseDnsSuffix",
                 TrafficManagerDnsSuffix = "TrafficManagerDnsSuffix",
                 GraphAudience = "GaraphAudience"
@@ -262,7 +262,7 @@ namespace Microsoft.Azure.Commands.ResourceManager.Profile.Test
             cmdlet.InvokeEndProcessing();
             Assert.Equal(cmdlet.Name, actual.Name);
             Assert.Equal(cmdlet.EnableAdfsAuthentication.ToBool(), actual.EnableAdfsAuthentication);
-            Assert.Equal(cmdlet.ActiveDirectoryEndpoint, actual.ActiveDirectoryAuthority);
+            Assert.Equal(cmdlet.ActiveDirectoryEndpoint + "/", actual.ActiveDirectoryAuthority, StringComparer.OrdinalIgnoreCase);
             Assert.Equal(cmdlet.ActiveDirectoryServiceEndpointResourceId,
                 actual.ActiveDirectoryServiceEndpointResourceId);
             Assert.Equal(cmdlet.AdTenant, actual.AdTenant);
@@ -281,6 +281,27 @@ namespace Microsoft.Azure.Commands.ResourceManager.Profile.Test
             commandRuntimeMock.Verify(f => f.WriteObject(It.IsAny<PSAzureEnvironment>()), Times.Once());
             AzureEnvironment env = AzureRmProfileProvider.Instance.Profile.Environments["KaTaL"];
             Assert.Equal(env.Name, cmdlet.Name);
+        }
+
+        [Fact]
+        [Trait(Category.AcceptanceType, Category.CheckIn)]
+        public void CreateEnvironmentWithTrailingSlashInActiveDirectory()
+        {
+            Mock<ICommandRuntime> commandRuntimeMock = new Mock<ICommandRuntime>();
+            PSAzureEnvironment actual = null;
+            commandRuntimeMock.Setup(f => f.WriteObject(It.IsAny<PSAzureEnvironment>()))
+                .Callback((object output) => actual = (PSAzureEnvironment)output);
+            var cmdlet = new AddAzureRMEnvironmentCommand()
+            {
+                CommandRuntime = commandRuntimeMock.Object,
+                Name = "Katal",
+                ActiveDirectoryEndpoint = "https://ActiveDirectoryEndpoint/"
+            };
+
+            cmdlet.InvokeBeginProcessing();
+            cmdlet.ExecuteCmdlet();
+            cmdlet.InvokeEndProcessing();
+            Assert.Equal(cmdlet.ActiveDirectoryEndpoint, actual.ActiveDirectoryAuthority, StringComparer.OrdinalIgnoreCase);
         }
 
 

--- a/src/ResourceManager/Profile/Commands.Profile/Environment/AddAzureRMEnvironment.cs
+++ b/src/ResourceManager/Profile/Commands.Profile/Environment/AddAzureRMEnvironment.cs
@@ -16,6 +16,7 @@ using Microsoft.Azure.Commands.Common.Authentication.Models;
 using Microsoft.Azure.Commands.Profile.Models;
 using Microsoft.Azure.Commands.ResourceManager.Common;
 using Microsoft.WindowsAzure.Commands.Common;
+using Microsoft.WindowsAzure.Commands.Utilities.Common;
 using System.Management.Automation;
 
 namespace Microsoft.Azure.Commands.Profile
@@ -123,7 +124,7 @@ namespace Microsoft.Azure.Commands.Profile
             newEnvironment.Endpoints[AzureEnvironment.Endpoint.ResourceManager] = ResourceManagerEndpoint;
             newEnvironment.Endpoints[AzureEnvironment.Endpoint.ManagementPortalUrl] = ManagementPortalUrl;
             newEnvironment.Endpoints[AzureEnvironment.Endpoint.StorageEndpointSuffix] = StorageEndpoint;
-            newEnvironment.Endpoints[AzureEnvironment.Endpoint.ActiveDirectory] = ActiveDirectoryEndpoint;
+            newEnvironment.Endpoints[AzureEnvironment.Endpoint.ActiveDirectory] = GeneralUtilities.EnsureTrailingSlash(ActiveDirectoryEndpoint);
             newEnvironment.Endpoints[AzureEnvironment.Endpoint.ActiveDirectoryServiceEndpointResourceId] = ActiveDirectoryServiceEndpointResourceId;
             newEnvironment.Endpoints[AzureEnvironment.Endpoint.Gallery] = GalleryEndpoint;
             newEnvironment.Endpoints[AzureEnvironment.Endpoint.Graph] = GraphEndpoint;

--- a/tools/AzureRM.BootStrapper/AzureRM.BootStrapper.Tests.ps1
+++ b/tools/AzureRM.BootStrapper/AzureRM.BootStrapper.Tests.ps1
@@ -1085,14 +1085,28 @@ Describe "Use-AzureRmProfile" {
 
         Context "Other versions of the same module found imported" {
             Mock Get-AzureRmModule -Verifiable { "1.0" } 
-            Mock Find-PotentialConflict -Verifiable { $false }
             $VersionObj = New-Object -TypeName System.Version -ArgumentList "2.0" 
             $moduleObj = New-Object -TypeName PSObject 
+            $moduleObj | Add-Member NoteProperty -Name "Name" -Value "Module1"
             $moduleObj | Add-Member NoteProperty Version($VersionObj)
             Mock Get-Module -Verifiable { $moduleObj }
             It "Should skip importing module" {
                 $result = Use-AzureRmProfile -Profile 'Profile1' -ErrorVariable useError -ErrorAction SilentlyContinue
-                $useError.exception.message.contains("A different version of module") | Should Be $true
+                $useError.exception.message.contains("A different profile version of module") | Should Be $true
+            }
+        }
+
+        # User tries to execute Use-AzureRmProfile with different profiles & different modules
+        Context "A different profile's module was previously imported" {
+            Mock Get-AzureRmModule -Verifiable { "1.0" } 
+            $VersionObj = New-Object -TypeName System.Version -ArgumentList "2.0" 
+            $moduleObj = New-Object -TypeName PSObject 
+            $moduleObj | Add-Member NoteProperty -Name "Name" -Value "Module1"
+            $moduleObj | Add-Member NoteProperty Version($VersionObj)
+            Mock Get-Module -Verifiable { $moduleObj }
+            It "Should skip importing module" {
+                $result = Use-AzureRmProfile -Profile 'Profile1' -Module 'Module1' -ErrorVariable useError -ErrorAction SilentlyContinue
+                $useError.exception.message.contains("A different profile version of module") | Should Be $true
             }
         }
     }

--- a/tools/AzureRM.BootStrapper/AzureRM.BootStrapper.psd1
+++ b/tools/AzureRM.BootStrapper/AzureRM.BootStrapper.psd1
@@ -63,7 +63,7 @@ CLRVersion = '4.0'
 # TypesToProcess = @()
 
 # Format files (.ps1xml) to be loaded when importing this module
-# FormatsToProcess = @()
+FormatsToProcess = '.\AzureRM.Bootstrapper.Format.ps1xml' 
 
 # Modules to import as nested modules of the module specified in RootModule/ModuleToProcess
 # NestedModules = @()

--- a/tools/AzureRM.BootStrapper/AzureRM.Bootstrapper.Format.ps1xml
+++ b/tools/AzureRM.BootStrapper/AzureRM.Bootstrapper.Format.ps1xml
@@ -1,0 +1,32 @@
+<?xml version="1.0" encoding="utf-8" ?>
+<Configuration>
+  <ViewDefinitions>
+    <View>
+      <Name>ProfileMapDataView</Name>
+      <ViewSelectedBy>
+        <TypeName>ProfileMapData</TypeName>
+      </ViewSelectedBy>
+      <ListControl>
+        <ListEntries>
+          <ListEntry>
+            <ListItems>
+              <ListItem>
+                <PropertyName>ProfileName</PropertyName>
+              </ListItem>
+              <ListItem>
+                <Label>Modules</Label>
+                <ScriptBlock> 
+                  $RequiredModules = "AzureRM", "AzureRM.Compute", "AzureRM.Websites", "AzureRM.Storage", "AzureRM.Sql"
+                  foreach ($name in $RequiredModules) 
+                  {
+                    ($_.psobject.properties | % { if ($_.name -eq $name) { $name + " : " + ( $_.value | ft -auto | out-string ) } } )
+                  }
+                </ScriptBlock>
+              </ListItem>
+            </ListItems>
+          </ListEntry>
+        </ListEntries>
+      </ListControl> 
+    </View>
+  </ViewDefinitions> 
+</Configuration>

--- a/tools/AzureRM.BootStrapper/AzureRM.Bootstrapper.psm1
+++ b/tools/AzureRM.BootStrapper/AzureRM.Bootstrapper.psm1
@@ -950,11 +950,23 @@ function Use-AzureRmProfile
         }
       }
 
-      # Block user if they try to import a module to the session where a different version of the same module is already imported
-      if ($null -ne (Get-Module -Name $Module | Where-Object { $_.Version -ne $version} ))
+      # If a different profile's Azure Module was imported, block user
+      $importedModules = Get-Module "Azure*"
+      foreach ($importedModule in $importedModules) 
       {
-        Write-Error "A different version of module $module is already imported in this session. Start a new PowerShell session and retry the operation."
-        return
+        $versions = $ProfileMap.$Profile.$($importedModule.Name)
+        if ($null -ne $versions)
+        {
+          # We need the latest version in that profile to be imported. If old version was imported, block user and ask to import in a new session
+          $versionEnum = $versions.GetEnumerator()
+          $toss = $versionEnum.MoveNext()
+          $version = $versionEnum.Current
+          if ([system.version]$version -ne $importedModule.Version)
+          {
+            Write-Error "A different profile version of module $importedModule is imported in this session. Start a new PowerShell session and retry the operation." -Category  InvalidOperation 
+            return
+          }
+        }
       }
 
       if ($PSCmdlet.ShouldProcess($module, "Importing module for profile $profile in the current scope"))


### PR DESCRIPTION
This checklist is used to make sure that common issues in a pull request are covered by the creator. You can find a more complete discussion of PowerShell cmdlet best practices [here](https://msdn.microsoft.com/en-us/library/dd878270(v=vs.85).aspx).

Below in **Overall Changes**, check off the boxes that apply to your PR. Within each of the categories that you select, make sure that you can check off **all** of the boxes.

## Overall Changes 
- [ ] [**MANDATORY** - General changes](#general)
- [ ] [**MANDATORY** - Add/remove/edit test(s)](#tests)
- [ ] [Add/remove/edit cmdlet(s)](#cmdlet-signature)
- [ ] [Add/remove/edit parameter(s)](#parameters)
- [ ] [Edit pipeline parameters](#parameters-and-the-pipeline)

### General
- [ ] Title of the PR is clear and informative
- [ ] There are a small number of commits that each have an informative message
- [ ] If it applies, references the bug/issue that the PR fixes
- [ ] All files have the Microsoft copyright header
- [ ] Cmdlets refer to management libraries through nuget references - no dlls are checked in
- [ ] The PR does not introduce breaking changes (unless a major version change occurs in the assembly and module)

### Tests
- [ ] PR includes test coverage for the included changes
- [ ] Tests must use xunit, and should either use Moq to mock management client calls, or use the scenario test framework
- [ ] PowerShell scripts used in tests must not use hard-coded values for location
- [ ] PowerShell scripts used in tests should do any necessary setup as part of the test or suite setup, and should not use hard-coded values for existing resources
- [ ] Tests should not use App.config files for settings
- [ ] Tests should use the built-in PowerShell functions for generating random names when unique names are necessary - this will store names in the test recording
- [ ] Tests should use Start-Sleep to pause rather than Thread.Sleep

### Cmdlet Signature
- [ ] Cmdlet name uses an approved PowerShell verb - use the enums for `VerbsCommon`, `VerbsCommunication`, `VerbsLifecycle`, `VerbsOther` whenever possible
- [ ] Cmdlet noun name uses the AzureRm prefix for management cmdlets, and the Azure prefix for data plane cmdlets
- [ ] Cmdlet specifies the `OutputType` attribute if any output is produced; if the cmdlet produces no output, it should implement a `PassThrough` parameter
- [ ] If the cmdlet makes changes or has side effects, it should implement `ShouldProcess` and have `SupportShouldProcess = true` specified in the cmdlet attribute. See a discussion about correct `ShouldProcess` implementation [here](https://gist.github.com/markcowl/338e16fe5c8bbf195aff9f8af0db585d#what-is-the-change)
- [ ] Cmdlets should derive from AzureRmCmdlet for management cmdlets, and AzureDataCmdlet for data cmdlets
- [ ] If multiple parameter sets are implemented, the cmdlet should specify a `DefaultParameterSetName` in its cmdlet attribute

### Parameters
- [ ] Cmdlets should have no more than four positional parameters
- [ ] Cmdlet parameter sets should be mutually exclusive - each parameter set must have at least one mandatory parameter not in other parameter sets
- [ ] Parameter types should not expose types from the management library - complex parameter types should be defined in the module
- [ ] Complex parameter types are discouraged - a parameter type should be simple types as often as possible. If complex types are used, they should be shallow and easily creatable from a constructor or another cmdlet
- [ ] Parameters should be explicitly marked as Mandatory or not, and should contain a HelpMessage
- [ ] No parameter is of type `object`.
    - Management cmdlets should have the following parameters and aliases:
        - ResourceGroupName with (optional) alias to `ResourceGroup` type string marked as [ValueFromPipelineByPropertyName]
        - Name with alias to `ResourceName` type string marked as [ValueFromPipelineByPropertyName]
        - Location (if appropriate) type string
        - Tag, type `HashTable`

### Parameters and the Pipeline
- [ ] Complex parameters should take values from the pipeline when possible, and certainly when they match the output type of another cmdlet
- [ ] Only one parameter should use ValueFromPipeline per parameter set; parameters from different parameter sets may have this attribute, but should not be convertible
- [ ] No parameter is of type `object`
- [ ] Each management cmdlet should have a parameter set that takes `ResourceGroupName` and `Name` from the pipeline by property value
- [ ] For a given resource type, it should be possible to pipe the output of `Get` and `New` cmdlets to the input of `Set`, `Update`, `Remove` and other action cmdlets for that resource
